### PR TITLE
s6-s6lockd.1: rename to s6lockd.1.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ man1_targets = \
 	s6-mkfifodir.1 \
 	s6-notifyoncheck.1 \
 	s6-permafailon.1 \
-	s6-s6lockd.1 \
+	s6lockd.1 \
 	s6-setlock.1 \
 	s6-setsid.1 \
 	s6-setuidgid.1 \

--- a/s6-local-service.7
+++ b/s6-local-service.7
@@ -104,7 +104,7 @@ Among them are:
 managing the reception of notifications and only waking up the client
 process when the notification pattern matches a regular expression.
 .It
-.Xr s6-s6lockd 1 ,
+.Xr s6lockd 1 ,
 handling time-constrained lock acquisition on client behalf.
 .It
 skadnsd[2],

--- a/s6-s6lock.7
+++ b/s6-s6lock.7
@@ -25,13 +25,13 @@ available.
 Given the nature of the
 .Nm
 library, it makes sense to use an
-.Xr s6-s6lockd 1
+.Xr s6lockd 1
 .Xr s6-local-service 7
 concurrently accessed by several applications using such locks to gate
 shared resources.
 .Pp
 If you're not using an
-.Xr s6-s6lockd 1
+.Xr s6lockd 1
 .Xr s6-local-service 7 ,
 make sure your application is not disturbed by children it doesn't
 know it has.
@@ -54,14 +54,14 @@ s6lock_start_g(&a, path, &deadline) ;
 .Pp
 .Fn s6lock_start_g
 starts a session by connecting to an
-.Xr s6-s6lockd 1
+.Xr s6lockd 1
 service listening on
 .Va path .
 The working directory is set by the administrator of the service.
 .Pp
 .Fn s6lock_startf_g
 starts a session with an
-.Xr s6-s6lockd 1
+.Xr s6lockd 1
 process as a child, using
 .Va lockdir
 as its working directory.
@@ -123,7 +123,7 @@ r = s6lock_release_g(&a, id, &deadline) ;
 .Pp
 .Fn s6lock_acquire_sh_g
 instructs the
-.Xr s6-s6lockd 1
+.Xr s6lockd 1
 daemon, related to the open session represented by the
 .Va a
 handle, to try and acquire a shared lock on the
@@ -195,7 +195,7 @@ it though.
 Call this function whenever the fd checks readability: it will update
 .Va a Ap
 s internal structures with information from the
-.Xr s6-s6lockd 1
+.Xr s6lockd 1
 daemon.
 It returns -1 if an error occurs; in case of success, it returns the
 number of identifiers for which something happened.
@@ -220,7 +220,7 @@ Use after a call to
 .It
 If an error occurred, returns -1 and sets errno.
 The error number may have been transmitted from
-.Xr s6-s6lockd 1 .
+.Xr s6lockd 1 .
 .It
 If the lock has not been acquired yet, returns 0.
 .It

--- a/s6-setlock.1
+++ b/s6-setlock.1
@@ -72,7 +72,7 @@ Exclusive lock.
 This is the default.
 .El
 .Sh SEE ALSO
-.Xr s6-s6lockd 1 ,
+.Xr s6lockd 1 ,
 .Xr s6lockd-helper 1
 .Pp
 This man page is ported from the authoritative documentation at:

--- a/s6lockd-helper.1
+++ b/s6lockd-helper.1
@@ -4,7 +4,7 @@
 .Sh NAME
 .Nm s6lockd-helper
 .Nd helper program for the
-.Xr s6-s6lockd 1
+.Xr s6lockd 1
 daemon
 .Sh DESCRIPTION
 .Nm
@@ -13,7 +13,7 @@ by its parent daemon.
 .Nm
 is not meant to be invoked directly by the user: it will be spawned by
 the
-.Xr s6-s6lockd 1
+.Xr s6lockd 1
 program.
 .Pp
 .Nm
@@ -44,7 +44,7 @@ Every instance should use up at most one or two pages of non-sharable
 memory.
 .El
 .Sh SEE ALSO
-.Xr s6-s6lockd 1 ,
+.Xr s6lockd 1 ,
 .Xr s6-setlock 1
 .Pp
 This man page is ported from the authoritative documentation at:

--- a/s6lockd.1
+++ b/s6lockd.1
@@ -1,8 +1,8 @@
 .Dd September 14, 2020
-.Dt S6-S6LOCKD 1
+.Dt S6LOCKD 1
 .Os
 .Sh NAME
-.Nm s6-s6lockd
+.Nm s6lockd
 .Nd
 .Xr s6-s6lock 7
 daemon which manages a set of lock files in a given directory, and


### PR DESCRIPTION
The executable is s6lockd, so don't add 's6-' to the manpage.